### PR TITLE
Flat fonts path instead of nested fonts folder

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,6 +31,9 @@ Encore
   })
   .cleanupOutputBeforeBuild([], () => {
     cp.spawnSync('git', ['clean', '-xdf', dest], { stdio: 'inherit' });
+  })
+  .configureFontRule({
+    filename: '[name].[hash:8][ext]',
   });
 
 module.exports = Encore.getWebpackConfig();


### PR DESCRIPTION
Webpack moves fonts inside assets/fonts, and Shopify doesn't support nested assets. This forces fonts to be inside assets folder directly.